### PR TITLE
Continue renaming from WebID to FedCM.

### DIFF
--- a/docs/fedcm.idl
+++ b/docs/fedcm.idl
@@ -39,13 +39,13 @@ partial interface FederatedCredential : Credential {
   static Promise<void> revoke(USVString accountId);
 };
 
-dictionary WebIdLogoutRequest {
+dictionary FederatedCredentialLogoutRequest {
     required USVString endpoint;
     required USVString accountId;
 };
 
 [Exposed=Window, SecureContext]
 partial interface FederatedCredential : Credential {
-  static Promise<void> logout(optional sequence<WebIdLogoutRequest> logout_requests = []);
+  static Promise<void> logout(optional sequence<FederatedCredentialLogoutRequest> logout_requests = []);
 };
 

--- a/explainer/HOWTO.md
+++ b/explainer/HOWTO.md
@@ -81,7 +81,7 @@ _Note that the UI for the mediation-oriented variation is still in development, 
 ### Permission-oriented variation protocol details
 
 #### Well-Known configuration request
-After the RP initiates a sign-in flow by calling the API, the browser learns about the IdP's FedCM support with a fetch to `https://idp.example/.well-known/federated-credentials`, where `https://idp.example` was specified as the provider by the RP.
+After the RP initiates a sign-in flow by calling the API, the browser learns about the IdP's FedCM support with a fetch to `https://idp.example/.well-known/fedcm`, where `https://idp.example` was specified as the provider by the RP.
 
 The browser expects a response with MIME type `application/json`, currently containing only one field:<br>
 ```json
@@ -124,7 +124,7 @@ The string should contain a [JWT](https://jwt.io/).
 ### Mediation-oriented variation protocol details
 
 #### Well-Known configuration request
-After the RP initiates a sign-in flow by calling the API, the browser learns about the IdP's FedCM support with a fetch to `https://idp.example/.well-known/federated-credentials`, where `https://idp.example` was specified as the provider by the RP.
+After the RP initiates a sign-in flow by calling the API, the browser learns about the IdP's FedCM support with a fetch to `https://idp.example/.well-known/fedcm`, where `https://idp.example` was specified as the provider by the RP.
 
 The browser expects a response with MIME type `application/json`, currently containing two fields:<br>
 ```json

--- a/explainer/HOWTO.md
+++ b/explainer/HOWTO.md
@@ -81,19 +81,19 @@ _Note that the UI for the mediation-oriented variation is still in development, 
 ### Permission-oriented variation protocol details
 
 #### Well-Known configuration request
-After the RP initiates a sign-in flow by calling the API, the browser learns about the IdP's FedCM support with a fetch to `https://idp.example/.well-known/webid`, where `https://idp.example` was specified as the provider by the RP.
+After the RP initiates a sign-in flow by calling the API, the browser learns about the IdP's FedCM support with a fetch to `https://idp.example/.well-known/federated-credentials`, where `https://idp.example` was specified as the provider by the RP.
 
 The browser expects a response with MIME type `application/json`, currently containing only one field:<br>
 ```json
 {
-  "idp_endpoint": "https://idp.example/webid/idp_endpoint"
+  "idp_endpoint": "https://idp.example/fedcm/idp_endpoint"
 }
 ```
 
 The `idp_endpoint` value provides the URL that the browser should use for the next step.
 
 #### ID token fetch
-The browser will then issue a credentialed `GET` request to `https://idp.example/webid/signin?{OAuth request string}`.
+The browser will then issue a credentialed `GET` request to `https://idp.example/fedcm/idp_endpoint?{OAuth request string}`.
 
 The browser expects one of two responses (both with MIME type `application/json`):
 1. If the IdP can reply immediately with a token to fulfill the sign-in token request:<br>
@@ -108,7 +108,7 @@ The browser expects one of two responses (both with MIME type `application/json`
 
 ```json
 {
-  "signin_url": "https://idp.example/webid/user_login"
+  "signin_url": "https://idp.example/fedcm/user_login"
 }
 ```
 
@@ -124,13 +124,13 @@ The string should contain a [JWT](https://jwt.io/).
 ### Mediation-oriented variation protocol details
 
 #### Well-Known configuration request
-After the RP initiates a sign-in flow by calling the API, the browser learns about the IdP's FedCM support with a fetch to `https://idp.example/.well-known/webid`, where `https://idp.example` was specified as the provider by the RP.
+After the RP initiates a sign-in flow by calling the API, the browser learns about the IdP's FedCM support with a fetch to `https://idp.example/.well-known/federated-credentials`, where `https://idp.example` was specified as the provider by the RP.
 
 The browser expects a response with MIME type `application/json`, currently containing two fields:<br>
 ```json
 {
-  "idtoken_endpoint": "https://idp.example/webid/webid_token_endpoint",
-  "accounts_endpoint": "https://idp.example/webid/webid_accounts_endpoint",
+  "idtoken_endpoint": "https://idp.example/fedcm/token_endpoint",
+  "accounts_endpoint": "https://idp.example/fedcm/accounts_endpoint",
 }
 ```
 

--- a/explainer/cookies.md
+++ b/explainer/cookies.md
@@ -88,7 +88,7 @@ The browser intercepts this invocation and runs the following algorithm for each
 
 ### Fetch Well-Known
 
-As a convention, the browser expects a `application/json` file to be hosted on the `.well-known/webid` path of the `provider` host.
+As a convention, the browser expects a `application/json` file to be hosted on the `.well-known/federated-credentials` path of the `provider` host.
 
 The configuration file is expected to have the following format:
 
@@ -182,7 +182,7 @@ The response of the `POST` request is expected to have the following layout:
 Here is an example of the `POST` request:
 
 ```http
-POST /webid/idtoken.php HTTP/1.1
+POST /fedcm/idtoken.php HTTP/1.1
 Host: idp.example
 Cookie: 123
 Content-Type: application/json

--- a/explainer/cookies.md
+++ b/explainer/cookies.md
@@ -88,7 +88,7 @@ The browser intercepts this invocation and runs the following algorithm for each
 
 ### Fetch Well-Known
 
-As a convention, the browser expects a `application/json` file to be hosted on the `.well-known/federated-credentials` path of the `provider` host.
+As a convention, the browser expects a `application/json` file to be hosted on the `.well-known/fedcm` path of the `provider` host.
 
 The configuration file is expected to have the following format:
 

--- a/explainer/directed_identifiers.md
+++ b/explainer/directed_identifiers.md
@@ -1,6 +1,6 @@
 * [Directed identifiers](#directed_identifiers)
 * [General implementation approaches](#general-implementation-approaches)
-* [Directed identifiers in FedCM](#directed-identifiers-in-webid)
+* [Directed identifiers in FedCM](#directed-identifiers-in-fedcm)
   * [Essential fields](#essential-fields)
   * [Other fields](#other-fields)
   * [Directed basic profile](#directed-basic-profile)
@@ -50,7 +50,7 @@ The remaining OIDC standard Claims have varying levels of value and usefulness i
 There are also non-standard Claims sometimes included in some federated sign-in scenarios, which do not necessarily violate the directedness requirements. An example is an IdP with multiple subscriber levels, in a case where it is useful for an RP to know which subscriber level is associated with that user. Adding a few bits of information should be possible, though it is an open question how the user agent can know that this does not pose a tracking risk requiring additional user consent, especially if there are other non-essential fields present that might cumulatively create undirected entropy.
 
 ## Directed basic profile
-This proposal defines the concept of a [directed basic profile](https://github.com/WICG/FedCM/blob/master/design.md#directed-basic-profile) which attempts to provide a set of directed fields that, when populated in a conforming way, can allow federated sign-in without risk of user tracking by identifier correlation. The precise definition of a directed basic profile is still a topic for dicussion.
+This proposal defines the concept of a [directed basic profile](https://github.com/WICG/FedCM/blob/master/design.md#directed-basic-profile) which attempts to provide a set of directed fields that, when populated in a conforming way, can allow federated sign-in without risk of user tracking by identifier correlation. The precise definition of a directed basic profile is still a topic for discussion.
 
 # User agent behavior
 The value of a directed identifier is that a user agent can cooperate with it being passed from an IdP to an RP without having to attempt to acquire user consent for the tracking risk that is associated with correlatable identifiers. The precise shape of the user consent flow is discussed elsewhere in the FedCM proposal.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
 Title: Federated Credential Management API
-Shortname: webid
+Shortname: FedCM
 Level: 1
 Status: CG-DRAFT
 Group: WICG
@@ -419,15 +419,16 @@ The [=IDP=] proactively and cooperatively exposes itself as a comformant agent b
 ## Manifest ## {#well-known}
 <!-- ============================================================ -->
 
-The well-known discovery endpoint is an endpoint located at the [=IDP=]'s `.well-known/webid` and serves as a discovery device to other endpoints provided by the [=IDP=].
+The well-known discovery endpoint is an endpoint located at the [=IDP=]'s
+`.well-known/federated-credentials` and serves as a discovery device to other endpoints provided by the [=IDP=].
 
-The well-known discovery endpoint is fetched (a) **without** cookies and (b) **with** a special [[#Sec-FedCM-CSR]] header.
+The well-known discovery endpoint is fetched (a) **without** cookies and (b) **with** a special [[#Sec-FedCM-CSRF]] header.
 
 For example:
 
 <div class=example>
 ```http
-GET /.well-known/webid HTTP/1.1
+GET /.well-known/federated-credentials HTTP/1.1
 Host: idp.example
 Accept: application/json
 Sec-FedCM-CSRF: random_value
@@ -466,7 +467,7 @@ For example:
 
 The accounts list endpoint provides the list of accounts the user has at the [=IDP=].
 
-The accounts list endpoint is fetched (a) **with** any cookies and (b) **with** a special [[#Sec-FedCM-CSR]] header.
+The accounts list endpoint is fetched (a) **with** any cookies and (b) **with** a special [[#Sec-FedCM-CSRF]] header.
 
 For example:
 
@@ -530,7 +531,7 @@ For example:
 
 The client metadata endpoint provides metadata about [=RP=]s.
 
-The client medata endpoint is fetched (a) **without** cookies and (b) **with** a special [[#Sec-FedCM-CSR]] header.
+The client medata endpoint is fetched (a) **without** cookies and (b) **with** a special [[#Sec-FedCM-CSRF]] header.
 
 The user agent also passes the **client_id**.
 
@@ -571,7 +572,7 @@ For example:
 
 The ID Token endpoint is responsible for minting a new [=id token=] for the user.
 
-The ID Token endpoint is fetched (a) as a **POST** request, (b)  **with** cookies and (c) **with** a special [[#Sec-FedCM-CSR]] header.
+The ID Token endpoint is fetched (a) as a **POST** request, (b)  **with** cookies and (c) **with** a special [[#Sec-FedCM-CSRF]] header.
 
 It will also contain the following parameters passed as a JSON object:
 
@@ -595,7 +596,7 @@ For example:
 
 <div class=example>
 ```http
-POST /webid_token_endpoint HTTP/1.1
+POST /fedcm_token_endpoint HTTP/1.1
 Host: idp.example
 Referer: rp.example
 Content-Type: application/json
@@ -637,7 +638,7 @@ The revocation endpoint is responsible for revoking all [=id token=]s for the
 specified client ID for the user.
 
 The revocation endpoint is fetched (a) as a **POST** request, (b)  **with**
-cookies, (c) **with** a special [[#Sec-FedCM-CSR]] header, and (d) **with**
+cookies, (c) **with** a special [[#Sec-FedCM-CSRF]] header, and (d) **with**
 a Referer header indicating the [=RP=] URL.
 
 It will also contain the following parameters passed as a JSON object:
@@ -660,7 +661,7 @@ For example:
 
 <div class=example>
 ```http
-POST /webid_revocation_endpoint HTTP/1.1
+POST /fedcm_revocation_endpoint HTTP/1.1
 Host: idp.example
 Referer: rp.example
 Content-Type: application/json
@@ -679,7 +680,7 @@ If successful, the response is an empty response with an HTTP 204 code,
 otherwise an HTTP error code.
 
 <!-- ============================================================ -->
-## <code><dfn data-export="">`Sec-FedCM-CSR`</dfn></code> ## {#Sec-FedCM-CSR}
+## <code><dfn data-export="">`Sec-FedCM-CSRF`</dfn></code> ## {#Sec-FedCM-CSRF}
 <!-- ============================================================ -->
 
 <!-- ============================================================ -->
@@ -936,9 +937,9 @@ To <dfn>explicit sign-in</dfn> the user run this algorithm:
 
 To <dfn>fetch the well-known</dfn> configuration file, run this algorithm:
 
-1. Let the |wellknown url| be the relative url ".well-known/webid" of |provider|["{{FederatedIdentityProvider/url}}"]
+1. Let the |wellknown url| be the relative url ".well-known/federated-credentials" of |provider|["{{FederatedIdentityProvider/url}}"]
 
-1. Return the result of fetching the |wellknown url| with the [[#Sec-FedCM-CSR|Sec-FedCM-CSR]] header but without the [=Identity Provider=]'s cookies.
+1. Return the result of fetching the |wellknown url| with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the [=Identity Provider=]'s cookies.
 
 To <dfn>fetch the accounts list</dfn> run this algorithm:
 
@@ -951,7 +952,7 @@ To <dfn>fetch the accounts list</dfn> run this algorithm:
 To <dfn>fetch the client id metadata</dfn> run this algorithm:
 
 1. Let the |client_id_metadata_endpoint| url be the relative url |wellknown|["{{WellKnown/client_id_metadata_endpoint}}"] of |provider|["{{FederatedIdentityProvider/url}}"]
-1. Let the |policies| be the result of fetching the |client_id_metadata_endpoint| with the [[#Sec-FedCM-CSR|Sec-FedCM-CSR]] header but without the [=Identity Provider=]'s cookies.
+1. Let the |policies| be the result of fetching the |client_id_metadata_endpoint| with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the [=Identity Provider=]'s cookies.
 1. Return |policies|
 
 The <dfn>Privacy Policy</dfn> are the policies described at {{client_id_metadata_endpont_response/privacy_policy_url}}.
@@ -1094,14 +1095,14 @@ async function logout() {
 [=IDP=]s can call <code><a idl for="FederatedCredential" lt="get()">FederatedCredential.logout(...)</a></code> to log the user out of the [=RP=]s they are signed into.
 
 <xmp class=idl>
-dictionary WebIdLogoutRequest {
+dictionary FederatedCredentialLogoutRequest {
     required USVString endpoint;
     required USVString accountId;
 };
 
 [Exposed=Window, SecureContext]
 partial interface FederatedCredential : Credential {
-  static Promise<void> logout(optional sequence<WebIdLogoutRequest> logout_requests = []);
+  static Promise<void> logout(optional sequence<FederatedCredentialLogoutRequest> logout_requests = []);
 };
 </xmp>
 
@@ -1688,10 +1689,6 @@ Note: write down the Acknowledgements section.
   "BrowserID": {
     "href": "https://github.com/mozilla/id-specs/blob/prod/browserid/index.md",
     "title": "BrowserID"
-  },
-  "FedCM": {
-    "href": "https://www.w3.org/2005/Incubator/webid/spec/identity/",
-    "title": "FedCM"
   },
   "CM": {
     "href": "https://w3c.github.io/webappsec-credential-management/",

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -420,7 +420,7 @@ The [=IDP=] proactively and cooperatively exposes itself as a comformant agent b
 <!-- ============================================================ -->
 
 The well-known discovery endpoint is an endpoint located at the [=IDP=]'s
-`.well-known/federated-credentials` and serves as a discovery device to other endpoints provided by the [=IDP=].
+`.well-known/fedcm` and serves as a discovery device to other endpoints provided by the [=IDP=].
 
 The well-known discovery endpoint is fetched (a) **without** cookies and (b) **with** a special [[#Sec-FedCM-CSRF]] header.
 
@@ -428,7 +428,7 @@ For example:
 
 <div class=example>
 ```http
-GET /.well-known/federated-credentials HTTP/1.1
+GET /.well-known/fedcm HTTP/1.1
 Host: idp.example
 Accept: application/json
 Sec-FedCM-CSRF: random_value
@@ -937,7 +937,7 @@ To <dfn>explicit sign-in</dfn> the user run this algorithm:
 
 To <dfn>fetch the well-known</dfn> configuration file, run this algorithm:
 
-1. Let the |wellknown url| be the relative url ".well-known/federated-credentials" of |provider|["{{FederatedIdentityProvider/url}}"]
+1. Let the |wellknown url| be the relative url ".well-known/fedcm" of |provider|["{{FederatedIdentityProvider/url}}"]
 
 1. Return the result of fetching the |wellknown url| with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the [=Identity Provider=]'s cookies.
 


### PR DESCRIPTION
This PR renames some missed webid's to fedcm. The `.well-known/webid`
location is updated to `.well-known/federated-credentials`. Various examples are updated
to use `fedcm` instead of `webid`.

The IDL files are updated to use `FederatedCredential` instead of `WebID` as a prefix.

Fixes #97
Fixes #101
Fixes #102


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dj2/FedCM/pull/107.html" title="Last updated on Oct 18, 2021, 6:53 PM UTC (5c6d968)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/FedCM/107/bd13566...dj2:5c6d968.html" title="Last updated on Oct 18, 2021, 6:53 PM UTC (5c6d968)">Diff</a>