### PR TITLE
Add workflow for spec generation.

### DIFF
--- a/.github/workflows/build-idl.yaml
+++ b/.github/workflows/build-idl.yaml
@@ -1,0 +1,29 @@
+name: Publish IDL to GitHub pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          make -C spec idl
+          mkdir out
+          cp docs/fedcm.idl out/
+
+      - name: Deploy
+        if: ${{ success() && github.ref == 'refs/heads/main' }}
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        with:
+          BRANCH: gh-pages
+          FOLDER: out
+          CLEAN-EXCLUDE:
+            index.html
+

--- a/.github/workflows/build-validate-publish.yaml
+++ b/.github/workflows/build-validate-publish.yaml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+
+jobs:
+  run:
+    name: Build, Validate, and Publish
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          GH_PAGES_BRANCH: gh-pages
+          BUILD_FAIL_ON: nothing
+          SOURCE: spec/index.bs
+          DESTINATION: index.html


### PR DESCRIPTION
This PR adds a GitHub workflow to verify the spec builds correctly on PR
request and to build the spec into the gh-pages branch on commit.

A second workflow is added to build the IDL file and move it into the
gh-pages branch.

Issue #105 