### PR TITLE
Update `Logout` to use `url`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7,12 +7,15 @@ Group: WICG
 ED: http://wicg.github.io/FedCM
 Repository: WICG/FedCM
 Editor: Sam Goto, Google Inc. https://google.com, goto@google.com
+
 Markup Shorthands: markdown yes, css no, biblio yes
 Default Biblio Display: inline
+
 Text Macro: FALSE <code>false</code>
 Text Macro: TRUE <code>true</code>
 Text Macro: RP Relying Party
 Text Macro: IDP Identity Provider
+
 Abstract: This specification defines a set of [=high-level API=]s that enables users to continue to use [=Identity Provider=]s to authenticate to [=Relying Party=]s without incurring into [[UNSANCTIONED-TRACKING]]. It accomplishes that by exposing the explicit user controls needed to manage the lifecycle of their federated accounts.
 Test Suite: https://github.com/web-platform-tests/wpt/blob/master/credential-management/webid.https.html
 </pre>
@@ -1094,10 +1097,10 @@ path: img/mock31.svg
 ```js
 async function logout() {
   await FederatedCredential.logout([{
-      endpoint: "https://rp1.example",
+      url: "https://rp1.example",
       accountId: "123",
     }, {
-      endpoint: "https://rpN.example",
+      url: "https://rpN.example",
       accountId: "456",
     }]);
 }
@@ -1108,7 +1111,7 @@ async function logout() {
 
 <xmp class=idl>
 dictionary FederatedCredentialLogoutRequest {
-    required USVString endpoint;
+    required USVString url;
     required USVString accountId;
 };
 


### PR DESCRIPTION
This PR changes the RP `logout` method to accept a `url` parameter
instead of an `endpoint` parameter. This makes the parameters consistent
with the `get` options which also take `url`.

Fixes #109


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dj2/FedCM/pull/132.html" title="Last updated on Nov 2, 2021, 3:57 AM UTC (a48f06a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/FedCM/132/4805186...dj2:a48f06a.html" title="Last updated on Nov 2, 2021, 3:57 AM UTC (a48f06a)">Diff</a>