### PR TITLE
Make explicit when cookies are for IDP.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -589,12 +589,10 @@ For example:
 
 The ID Token endpoint is responsible for [=minting=] a new [=id token=] for the user.
 
-The ID Token endpoint is fetched (a) as a **POST** request, (b)  **with** cookies and (c) **with** a special [[#Sec-FedCM-CSRF]] header.
 The ID Token endpoint is fetched
 (a) as a **POST** request,
 (b) **with** cookies,
 (c) **with** a special [[#Sec-FedCM-CSRF]] header and
-(d) **with** a Referer header indicating the [=RP=] URL.
 
 It will also contain the following parameters passed as a JSON object:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -591,7 +591,7 @@ The ID Token endpoint is responsible for [=minting=] a new [=id token=] for the 
 
 The ID Token endpoint is fetched
 (a) as a **POST** request,
-(b) **with** cookies,
+(b) **with** [=IDP=] cookies,
 (c) **with** a special [[#Sec-FedCM-CSRF]] header and
 
 It will also contain the following parameters passed as a JSON object:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -433,7 +433,9 @@ The [=IDP=] proactively and cooperatively exposes itself as a comformant agent b
 The well-known discovery endpoint is an endpoint located at the [=IDP=]'s
 `.well-known/fedcm` and serves as a discovery device to other endpoints provided by the [=IDP=].
 
-The well-known discovery endpoint is fetched (a) **without** cookies and (b) **with** a special [[#Sec-FedCM-CSRF]] header.
+The well-known discovery endpoint is fetched
+(a) **without** cookies and
+(b) **with** a special [[#Sec-FedCM-CSRF]] header.
 
 For example:
 
@@ -478,7 +480,9 @@ For example:
 
 The accounts list endpoint provides the list of accounts the user has at the [=IDP=].
 
-The accounts list endpoint is fetched (a) **with** any cookies and (b) **with** a special [[#Sec-FedCM-CSRF]] header.
+The accounts list endpoint is fetched
+(a) **with** [=IDP=] cookies and
+(b) **with** a special [[#Sec-FedCM-CSRF]] header.
 
 For example:
 
@@ -542,7 +546,9 @@ For example:
 
 The client metadata endpoint provides metadata about [=RP=]s.
 
-The client medata endpoint is fetched (a) **without** cookies and (b) **with** a special [[#Sec-FedCM-CSRF]] header.
+The client medata endpoint is fetched
+(a) **without** cookies and
+(b) **with** a special [[#Sec-FedCM-CSRF]] header.
 
 The user agent also passes the **client_id**.
 
@@ -584,6 +590,11 @@ For example:
 The ID Token endpoint is responsible for [=minting=] a new [=id token=] for the user.
 
 The ID Token endpoint is fetched (a) as a **POST** request, (b)  **with** cookies and (c) **with** a special [[#Sec-FedCM-CSRF]] header.
+The ID Token endpoint is fetched
+(a) as a **POST** request,
+(b) **with** cookies,
+(c) **with** a special [[#Sec-FedCM-CSRF]] header and
+(d) **with** a Referer header indicating the [=RP=] URL.
 
 It will also contain the following parameters passed as a JSON object:
 
@@ -648,9 +659,11 @@ For example:
 The revocation endpoint is responsible for revoking all [=id token=]s for the
 specified client ID for the user.
 
-The revocation endpoint is fetched (a) as a **POST** request, (b)  **with**
-cookies, (c) **with** a special [[#Sec-FedCM-CSRF]] header, and (d) **with**
-a Referer header indicating the [=RP=] URL.
+The revocation endpoint is fetched
+(a) as a **POST** request,
+(b) **with** [=IDP=] cookies,
+(c) **with** a special [[#Sec-FedCM-CSRF]] header, and
+(d) **with** a Referer header indicating the [=RP=] URL.
 
 It will also contain the following parameters passed as a JSON object:
 
@@ -711,7 +724,9 @@ via the logout endpoint.
 The logout endpoint is an endpoint that is registered with the [=IDP=]
 [=out-of-band=].
 
-The logout endpoint is called (a) with a **GET** and (b) with the [=RP=]'s cookies.
+The logout endpoint is called
+(a) with a **GET** and
+(b) with the [=RP=]'s cookies.
 
 Note: the logout API introduces a credentialed request from the [=IDP=] to
 the [=RP=]s, so it exposes a potential tracking surface area. It is a fairly


### PR DESCRIPTION
The various IDP endpoints list sending with cookies but don't specify
that they are IDP cookies. This PR makes the spec explicit when the
cookies are IDP cookies (the one instance of RP cookies was already
explicit).

Fixes #115


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dj2/FedCM/pull/135.html" title="Last updated on Nov 5, 2021, 1:26 AM UTC (685b473)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/FedCM/135/2ae2dc6...dj2:685b473.html" title="Last updated on Nov 5, 2021, 1:26 AM UTC (685b473)">Diff</a>