### PR TITLE
Make nonce optional in FederatedIdentityProvider

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -897,7 +897,7 @@ partial dictionary FederatedCredentialRequestOptions {
 dictionary FederatedIdentityProvider {
   required USVString url;
   required USVString clientId;
-  required USVString nonce;
+  USVString nonce;
 };
 </xmp>
 


### PR DESCRIPTION
As suggested by some IDP, nonce should not be required. When RP doesn't specify a nonce, IDP will create one for them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yi-gu/FedCM/pull/159.html" title="Last updated on Dec 2, 2021, 7:26 PM UTC (9dcff1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/FedCM/159/3dcbaeb...yi-gu:9dcff1d.html" title="Last updated on Dec 2, 2021, 7:26 PM UTC (9dcff1d)">Diff</a>